### PR TITLE
Pass the protocol-specific error code inside ProxyError

### DIFF
--- a/aiohttp_socks/proxy/errors.py
+++ b/aiohttp_socks/proxy/errors.py
@@ -1,5 +1,7 @@
 class ProxyError(Exception):
-    pass
+    def __init__(self, message, error_code=None):
+        super().__init__(message)
+        self.error_code = error_code
 
 
 class ProxyConnectionError(OSError):

--- a/aiohttp_socks/proxy/http_proxy.py
+++ b/aiohttp_socks/proxy/http_proxy.py
@@ -62,4 +62,4 @@ class HttpProxy(BaseProxy):
 
         if status_code != 200:
             raise ProxyError(  # pragma: no cover
-                'Proxy server error. Status: {}'.format(status_code))
+                'Proxy server error. Status: {}'.format(status_code), status_code)

--- a/aiohttp_socks/proxy/socks4_proxy.py
+++ b/aiohttp_socks/proxy/socks4_proxy.py
@@ -77,4 +77,4 @@ class Socks4Proxy(BaseProxy):
 
         if code != SOCKS4_GRANTED:  # pragma: no cover
             error = SOCKS4_ERRORS.get(code, 'Unknown error')
-            raise ProxyError('[Errno {0:#04x}]: {1}'.format(code, error))
+            raise ProxyError('[Errno {0:#04x}]: {1}'.format(code, error), error)

--- a/aiohttp_socks/proxy/socks5_proxy.py
+++ b/aiohttp_socks/proxy/socks5_proxy.py
@@ -109,7 +109,7 @@ class Socks5Proxy(BaseProxy):
             raise ProxyError('Unexpected SOCKS version number: {}'.format(ver))
 
         if err_code != NULL:
-            raise ProxyError(SOCKS5_ERRORS.get(err_code, 'Unknown error'))
+            raise ProxyError(SOCKS5_ERRORS.get(err_code, 'Unknown error'), err_code)
 
         if reserved != RSV:
             raise ProxyError('The reserved byte must be 0x00')


### PR DESCRIPTION
Allows accessing the error code without string parsing.