### PR TITLE
Return errcode instead of error for SOCKS4

### DIFF
--- a/aiohttp_socks/proxy/socks4_proxy.py
+++ b/aiohttp_socks/proxy/socks4_proxy.py
@@ -78,4 +78,4 @@ class Socks4Proxy(BaseProxy):
         if code != SOCKS4_GRANTED:  # pragma: no cover
             error = SOCKS4_ERRORS.get(code, 'Unknown error')
             raise ProxyError('[Errno {0:#04x}]: {1}'.format(code, error),
-                             error)
+                             code)


### PR DESCRIPTION
Sorry for the hassle, but I just realized that the wrong variable was being passed as error code for SOCKS4...