### PR TITLE
Fix family param

### DIFF
--- a/aiohttp_socks/connector.py
+++ b/aiohttp_socks/connector.py
@@ -34,7 +34,7 @@ class SocksConnector(TCPConnector):  # pragma: no cover
         if rdns:
             kwargs['resolver'] = NoResolver()
 
-        super().__init__(**kwargs)
+        super().__init__(family=family, **kwargs)
 
         self._socks_ver = socks_ver
         self._socks_host = host


### PR DESCRIPTION
Without this fix there was no way to passed "family" to aiohttp TCPConnector. As u see, **kwargs didnt contain "family", so this parameter must be passed directly.