### PR TITLE
Added support for Custom DNS resolver when using proxy (Asyncio).

### DIFF
--- a/aiohttp_socks/connector.py
+++ b/aiohttp_socks/connector.py
@@ -51,6 +51,7 @@ class ProxyConnector(TCPConnector):
         password=None,
         rdns=None,
         proxy_ssl=None,
+        proxy_resolver=None,
         **kwargs,
     ):
         kwargs['resolver'] = NoResolver()
@@ -63,6 +64,7 @@ class ProxyConnector(TCPConnector):
         self._proxy_password = password
         self._rdns = rdns
         self._proxy_ssl = proxy_ssl
+        self._proxy_resolver=proxy_resolver
 
     # noinspection PyMethodOverriding
     async def _wrap_create_connection(self, protocol_factory, host, port, *, ssl, **kwargs):
@@ -74,6 +76,7 @@ class ProxyConnector(TCPConnector):
             password=self._proxy_password,
             rdns=self._rdns,
             proxy_ssl=self._proxy_ssl,
+            resolver=self._proxy_resolver
         )
 
         connect_timeout = None


### PR DESCRIPTION



```
import socket
import asyncio
import aiohttp

from aiohttp_socks import ProxyType, ProxyConnector
from python_socks.async_.asyncio._resolver import Resolver
from aiohttp import AsyncResolver


class CustomResolver(Resolver):

    def __init__(self, loop: asyncio.AbstractEventLoop):
        super().__init__(loop)
        self.resolver = AsyncResolver(loop, nameservers=['208.67.222.123'], udp_port=5353)

    async def resolve(self, host, port=0, family=socket.AF_UNSPEC):
        hosts = await self.resolver.resolve(host, port, family)
        return '', hosts[0]['host']


async def main():
    loop = asyncio.get_event_loop()
    resolver = CustomResolver(loop)
    proxy_host = '199.102.104.70'
    proxy_port = 4145

    connector = ProxyConnector(proxy_type=ProxyType.SOCKS5,
                               host=proxy_host,
                               port=proxy_port,
                               rdns=False,
                               proxy_resolver=resolver,
                               ssl=False
                               )
    async with aiohttp.ClientSession(connector=connector) as session:
        async with session.get("http://ipapi.co/json") as resp:
            print(await resp.json())


if __name__ == '__main__':
    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
    asyncio.run(main())

```