### PR TITLE
fix ProxyConnector port type hint: str -> int

### DIFF
--- a/aiohttp_socks/connector.py
+++ b/aiohttp_socks/connector.py
@@ -84,7 +84,7 @@ class ProxyConnector(_BaseProxyConnector):
     def __init__(
         self,
         host: str,
-        port: str,
+        port: int,
         proxy_type: ProxyType = ProxyType.SOCKS5,
         username: Optional[str] = None,
         password: Optional[str] = None,


### PR DESCRIPTION
Proxy expects `port` to be `int`, not `str`