### PR TITLE
Fix test compatibility with pytest-asyncio >= 1.0.0

### DIFF
--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -272,7 +272,6 @@ async def test_socks5_open_connection(url, rdns, target_ssl_context):
 async def test_socks5_http_create_connection(
     url: str,
     rdns: bool,
-    event_loop: asyncio.AbstractEventLoop,
     target_ssl_context: ssl.SSLContext,
 ):
     url = URL(url)
@@ -281,6 +280,7 @@ async def test_socks5_http_create_connection(
     if url.scheme == 'https':
         ssl_context = target_ssl_context
 
+    event_loop = asyncio.get_running_loop()
     reader = asyncio.StreamReader(loop=event_loop)
     protocol = asyncio.StreamReaderProtocol(reader, loop=event_loop)
 


### PR DESCRIPTION
Replace the obsolete `event_loop` fixture with
`asyncio.get_running_loop()`, to fix testing with newer versions of `pytest-asyncio`.  This change is backwards compatible.